### PR TITLE
ci: increase download buffer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: cachix/install-nix-action@v31
         with:
           extra_nix_config: |
-            nix.settings.download-buffer-size = 524288000
+            download-buffer-size = 524288000
       - uses: cachix/cachix-action@v16
         with:
           name: planet-a-ventures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            nix.settings.download-buffer-size = 524288000
       - uses: cachix/cachix-action@v16
         with:
           name: planet-a-ventures


### PR DESCRIPTION
fixes `warning: download buffer is full; consider increasing the 'download-buffer-size' setting`, see https://github.com/planet-a-ventures/dlt-source-airtable/actions/runs/14496093943/job/40664132921#step:5:1000

refs https://github.com/NixOS/nix/issues/11728